### PR TITLE
Update package.json: New export Syntax from svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "An accessible dialog component for Svelte apps",
   "author": "Reece Lucas <reecelucas@sky.com>",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
At startup of my sveltekit application ive been seeing this warning message:

```
18:33:18 [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-accessible-dialog@2.1.3

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

[According to the docs](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition), the package.json needs to get updates. This is what this PR does.